### PR TITLE
fix: Write defaultCors to correct path, output with x-amazon-apigateway-integration key

### DIFF
--- a/src/api/definition.ts
+++ b/src/api/definition.ts
@@ -115,7 +115,6 @@ export class ApiDefinition extends apigateway.ApiDefinition {
       if (typeof defaultCors !== 'undefined') {
         this.schema.set(`paths.${path}.options`, {
           'x-amazon-apigateway-integration': defaultCors.xAmazonApigatwayIntegration,
-          'type': defaultCors.type,
         });
       }
 

--- a/src/api/definition.ts
+++ b/src/api/definition.ts
@@ -113,7 +113,7 @@ export class ApiDefinition extends apigateway.ApiDefinition {
       }
 
       if (typeof defaultCors !== 'undefined') {
-        this.schema.set(`${path}.options`, defaultCors);
+        this.schema.set(`paths.${path}.options`, defaultCors);
       }
 
       const methods = paths[path];

--- a/src/api/definition.ts
+++ b/src/api/definition.ts
@@ -113,7 +113,10 @@ export class ApiDefinition extends apigateway.ApiDefinition {
       }
 
       if (typeof defaultCors !== 'undefined') {
-        this.schema.set(`paths.${path}.options`, defaultCors);
+        this.schema.set(`paths.${path}.options`, {
+          'x-amazon-apigateway-integration': defaultCors.xAmazonApigatwayIntegration,
+          'type': defaultCors.type,
+        });
       }
 
       const methods = paths[path];

--- a/src/integration/cors.ts
+++ b/src/integration/cors.ts
@@ -33,7 +33,7 @@ export class CorsIntegration extends Integration {
   /** Build Apache Velocity (`.vtl`) template for CORS response. */
   private static buildTemplate(origins: string): string {
     const originsForTmpl = origins.split(',').map(o => `"${o}"`).join(',');
-    const tmpl = template.replace('__DOMAIN__', originsForTmpl);
+    const tmpl = template.replace('__DOMAINS__', originsForTmpl);
     return tmpl;
   }
 


### PR DESCRIPTION
Fixes #26 

This writes the `defaultCors` output to `paths.${path}.options`, with the integration key `x-amazon-apigateway-integration`

Here is the generated document from the hello-api example with this fix:

```
{
  "openapi": "3.0.3",
  "info": {
    "title": "Hello API",
    "description": "Defines an example “Hello World” API",
    "version": "0.0.1"
  },
  "paths": {
    "/": {
      "get": {
        "operationId": "sayHello",
        "summary": "Say Hello",
        "description": "Prints out a greeting",
        "parameters": [
          {
            "name": "name",
            "in": "query",
            "required": false,
            "schema": {
              "type": "string",
              "default": "World"
            }
          }
        ],
        "responses": {
          "200": {
            "description": "Successful response",
            "content": {
              "application/json": {
                "schema": {
                  "$ref": "#/components/schemas/HelloResponse"
                }
              }
            }
          }
        },
        "x-amazon-apigateway-integration": {
          "httpMethod": "POST",
          "responses": {},
          "type": "AWS_PROXY",
          "uri": "arn:${Token[AWS.Partition.10]}:apigateway:${Token[AWS.Region.11]}:lambda:path/2015-03-31/functions/${Token[TOKEN.412]}/invocations"
        }
      },
      "options": {
        "x-amazon-apigateway-integration": {
          "httpMethod": "POST",
          "responses": {
            "default": {
              "statusCode": "204",
              "responseParameters": {
                "method.response.header.Access-Control-Allow-Methods": "*",
                "method.response.header.Access-Control-Allow-Headers": "*"
              },
              "responseTemplates": {
                "application/json": "$input.json(\"$\")\n#set($domains = [__DOMAINS__])\n#set($origin = $input.params(\"origin\"))\n#if($domains.size()==0)\n#set($context.responseOverride.header.Access-Control-Allow-Origin=\"*\")\n#elseif($domains.contains($origin))\n#set($context.responseOverride.header.Access-Control-Allow-Origin=\"$origin\")\n#end"
              }
            }
          },
          "type": "MOCK"
        },
        "type": "CORS"
      }
    }
  },
  "components": {
    "schemas": {
      "HelloResponse": {
        "description": "Response body",
        "type": "object",
        "properties": {
          "message": {
            "type": "string",
            "description": "Greeting",
            "example": "Hello World!"
          }
        }
      }
    }
  }
}
```