### PR TITLE
fix: Update @types/prettier to 2.6.0 in projen, generate updated package.json. Fixes install error on npm 8.

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -24,7 +24,7 @@
     },
     {
       "name": "@types/prettier",
-      "version": "v2.6.0",
+      "version": "2.6.0",
       "type": "build"
     },
     {

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -34,7 +34,7 @@ const project = new awscdk.AwsCdkConstructLibrary({
     '@types/lodash',
     '@types/js-yaml',
     '@types/omit-deep-lodash',
-    '@types/prettier@v2.6.0',
+    '@types/prettier@2.6.0',
     '@types/semver',
   ],
   bundledDeps: [

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@types/lodash": "^4.14.184",
     "@types/node": "^14",
     "@types/omit-deep-lodash": "^1.1.1",
-    "@types/prettier": "v2.6.0",
+    "@types/prettier": "2.6.0",
     "@types/semver": "^7.3.12",
     "@typescript-eslint/eslint-plugin": "^5",
     "@typescript-eslint/parser": "^5",


### PR DESCRIPTION
Fixes #30

`@types/prettier` was specified in `.projenrc.js` as `v2.6.0`, which caused `projen` to generate an invalid `package.json` which had a mismatch between the version of `@types/prettier` in `devDependencies` (`v2.6.0`) and the version in `overrides` (`2.6.0`).  This causes an install error when using npm 8.

Changing the version of `@types/prettier` in `.projenrc.js` to `2.6.0` (dropping the leading `v`) fixes the mismatch.