### PR TITLE
fix: add requestTemplates to CorsIntegration options

### DIFF
--- a/src/integration/cors.ts
+++ b/src/integration/cors.ts
@@ -56,6 +56,7 @@ export class CorsIntegration extends Integration {
     const integration: IntegrationProps = {
       type: IntegrationType.MOCK,
       options: {
+        requestTemplates: { 'application/json': '{"statusCode": 204}' },
         integrationResponses: [
           {
             statusCode: '204',


### PR DESCRIPTION
Add requestTemplates returning statusCode 204 to CorsIntegration options.
Reference: [Enable CORS on a resource using the API Gateway import API](https://docs.aws.amazon.com/apigateway/latest/developerguide/enable-cors-for-resource-using-swagger-importer-tool.html)

Fixes: #37