### PR TITLE
fix: return Access-Control-Allow-Origin: "*" on CorsOrigins.ANY

### DIFF
--- a/src/integration/cors.ts
+++ b/src/integration/cors.ts
@@ -1,14 +1,12 @@
-//import { readFileSync } from 'fs';
 import { IntegrationProps, IntegrationType } from 'aws-cdk-lib/aws-apigateway';
 import { Construct } from 'constructs';
 import { Integration, IntegrationConfig, InternalIntegrationType, ValidatorConfig } from './base';
-//const template = readFileSync(__dirname+'/cors.vtl', 'utf-8');
 
 const template = `
 $input.json("$")
 #set($domains = [__DOMAINS__])
 #set($origin = $input.params("origin"))
-#if($domains.size()==0)
+#if($domains.size() == 1 && $domains[0] == "*")
 #set($context.responseOverride.header.Access-Control-Allow-Origin="*")
 #elseif($domains.contains($origin))
 #set($context.responseOverride.header.Access-Control-Allow-Origin="$origin")

--- a/src/integration/cors.vtl
+++ b/src/integration/cors.vtl
@@ -1,8 +1,0 @@
-$input.json("$")
-#set($domains = [__DOMAINS__])
-#set($origin = $input.params("origin"))
-#if($domains.size()==0)
-#set($context.responseOverride.header.Access-Control-Allow-Origin="*")
-#elseif($domains.contains($origin))
-#set($context.responseOverride.header.Access-Control-Allow-Origin="$origin")
-#end


### PR DESCRIPTION
Fix a logic error in cors integration response VTL. If CorsIntegration is configured with options.origins: CorsOrigins.ANY or '\*', template will never satisfy condition that `$domains.size() == 0`, because `$domains` array will contain a single member '\*'. As a result, `Access-Control-Allow-Origin` header is never set on the response.

Fixes: #39 