### PR TITLE
feat: add Methods class to allow jsii compilation

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -62,8 +62,6 @@ const project = new awscdk.AwsCdkConstructLibrary({
     '/examples/**/.git',
     '.vscode',
   ],
-
-
 });
 
 

--- a/API.md
+++ b/API.md
@@ -4145,8 +4145,8 @@ const xAmazonApigatewayIntegration: XAmazonApigatewayIntegration = { ... }
 | [`contentHandling`](#almacdkopenapixxamazonapigatewayintegrationpropertycontenthandling) | [`aws-cdk-lib.aws_apigateway.ContentHandling`](#aws-cdk-lib.aws_apigateway.ContentHandling) | Response payload encoding conversion types. |
 | [`credentials`](#almacdkopenapixxamazonapigatewayintegrationpropertycredentials) | `string` | For AWS IAM role-based credentials, specify the ARN of an appropriate IAM role. |
 | [`passthroughBehavior`](#almacdkopenapixxamazonapigatewayintegrationpropertypassthroughbehavior) | [`aws-cdk-lib.aws_apigateway.PassthroughBehavior`](#aws-cdk-lib.aws_apigateway.PassthroughBehavior) | Specifies how a request payload of unmapped content type is passed through the integration request without modification. |
-| [`requestParameters`](#almacdkopenapixxamazonapigatewayintegrationpropertyrequestparameters) | [`@alma-cdk/openapix.XAmazonApigatewayIntegrationRequestParameters`](#@alma-cdk/openapix.XAmazonApigatewayIntegrationRequestParameters) | Specifies mappings from method request parameters to integration request parameters. |
-| [`requestTemplates`](#almacdkopenapixxamazonapigatewayintegrationpropertyrequesttemplates) | [`@alma-cdk/openapix.XAmazonApigatewayIntegrationRequestTemplates`](#@alma-cdk/openapix.XAmazonApigatewayIntegrationRequestTemplates) | Mapping templates for a request payload of specified MIME types. |
+| [`requestParameters`](#almacdkopenapixxamazonapigatewayintegrationpropertyrequestparameters) | {[ key: string ]: `string`} | Specifies mappings from method request parameters to integration request parameters. |
+| [`requestTemplates`](#almacdkopenapixxamazonapigatewayintegrationpropertyrequesttemplates) | {[ key: string ]: `string`} | Mapping templates for a request payload of specified MIME types. |
 | [`responses`](#almacdkopenapixxamazonapigatewayintegrationpropertyresponses) | [`@alma-cdk/openapix.XAmazonApigatewayIntegrationResponses`](#@alma-cdk/openapix.XAmazonApigatewayIntegrationResponses) | Defines the method's responses and specifies desired parameter mappings or payload mappings from integration responses to method responses. |
 | [`timeoutInMillis`](#almacdkopenapixxamazonapigatewayintegrationpropertytimeoutinmillis) | `number` | Integration timeouts between 50 ms and 29,000 ms. |
 | [`tlsConfig`](#almacdkopenapixxamazonapigatewayintegrationpropertytlsconfig) | [`@alma-cdk/openapix.XAmazonApigatewayIntegrationTlsConfig`](#@alma-cdk/openapix.XAmazonApigatewayIntegrationTlsConfig) | Specifies the TLS configuration for an integration. |
@@ -4293,10 +4293,10 @@ Supported values are when_no_templates, when_no_match, and never
 ##### `requestParameters`<sup>Optional</sup> <a name="@alma-cdk/openapix.XAmazonApigatewayIntegration.property.requestParameters" id="almacdkopenapixxamazonapigatewayintegrationpropertyrequestparameters"></a>
 
 ```typescript
-public readonly requestParameters: XAmazonApigatewayIntegrationRequestParameters;
+public readonly requestParameters: {[ key: string ]: string};
 ```
 
-- *Type:* [`@alma-cdk/openapix.XAmazonApigatewayIntegrationRequestParameters`](#@alma-cdk/openapix.XAmazonApigatewayIntegrationRequestParameters)
+- *Type:* {[ key: string ]: `string`}
 
 Specifies mappings from method request parameters to integration request parameters.
 
@@ -4307,10 +4307,10 @@ Supported request parameters are querystring, path, header, and body.
 ##### `requestTemplates`<sup>Optional</sup> <a name="@alma-cdk/openapix.XAmazonApigatewayIntegration.property.requestTemplates" id="almacdkopenapixxamazonapigatewayintegrationpropertyrequesttemplates"></a>
 
 ```typescript
-public readonly requestTemplates: XAmazonApigatewayIntegrationRequestTemplates;
+public readonly requestTemplates: {[ key: string ]: string};
 ```
 
-- *Type:* [`@alma-cdk/openapix.XAmazonApigatewayIntegrationRequestTemplates`](#@alma-cdk/openapix.XAmazonApigatewayIntegrationRequestTemplates)
+- *Type:* {[ key: string ]: `string`}
 
 Mapping templates for a request payload of specified MIME types.
 
@@ -4352,36 +4352,6 @@ Specifies the TLS configuration for an integration.
 
 ---
 
-### XAmazonApigatewayIntegrationRequestParameters <a name="@alma-cdk/openapix.XAmazonApigatewayIntegrationRequestParameters" id="almacdkopenapixxamazonapigatewayintegrationrequestparameters"></a>
-
-Specifies mappings from named method request parameters to integration request parameters.
-
-The method request parameters must be defined before being referenced.
-
-> https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-swagger-extensions-integration-requestParameters.html
-
-#### Initializer <a name="[object Object].Initializer" id="object-objectinitializer"></a>
-
-```typescript
-import { XAmazonApigatewayIntegrationRequestParameters } from '@alma-cdk/openapix'
-
-const xAmazonApigatewayIntegrationRequestParameters: XAmazonApigatewayIntegrationRequestParameters = { ... }
-```
-
-
-### XAmazonApigatewayIntegrationRequestTemplates <a name="@alma-cdk/openapix.XAmazonApigatewayIntegrationRequestTemplates" id="almacdkopenapixxamazonapigatewayintegrationrequesttemplates"></a>
-
-Specifies mapping templates for a request payload of the specified MIME types.
-
-#### Initializer <a name="[object Object].Initializer" id="object-objectinitializer"></a>
-
-```typescript
-import { XAmazonApigatewayIntegrationRequestTemplates } from '@alma-cdk/openapix'
-
-const xAmazonApigatewayIntegrationRequestTemplates: XAmazonApigatewayIntegrationRequestTemplates = { ... }
-```
-
-
 ### XAmazonApigatewayIntegrationResponse <a name="@alma-cdk/openapix.XAmazonApigatewayIntegrationResponse" id="almacdkopenapixxamazonapigatewayintegrationresponse"></a>
 
 Defines a response and specifies parameter mappings or payload mappings from the integration response to the method response.
@@ -4402,8 +4372,8 @@ const xAmazonApigatewayIntegrationResponse: XAmazonApigatewayIntegrationResponse
 | --- | --- | --- |
 | [`statusCode`](#almacdkopenapixxamazonapigatewayintegrationresponsepropertystatuscode)<span title="Required">*</span> | `string` | HTTP status code for the method response. |
 | [`contentHandling`](#almacdkopenapixxamazonapigatewayintegrationresponsepropertycontenthandling) | [`aws-cdk-lib.aws_apigateway.ContentHandling`](#aws-cdk-lib.aws_apigateway.ContentHandling) | Response payload encoding conversion types. |
-| [`responseParameters`](#almacdkopenapixxamazonapigatewayintegrationresponsepropertyresponseparameters) | [`@alma-cdk/openapix.XAmazonApigatewayIntegrationResponseParameters`](#@alma-cdk/openapix.XAmazonApigatewayIntegrationResponseParameters) | Specifies parameter mappings for the response. |
-| [`responseTemplates`](#almacdkopenapixxamazonapigatewayintegrationresponsepropertyresponsetemplates) | [`@alma-cdk/openapix.XAmazonApigatewayIntegrationResponseTemplates`](#@alma-cdk/openapix.XAmazonApigatewayIntegrationResponseTemplates) | Specifies MIME type-specific mapping templates for the response’s payload. |
+| [`responseParameters`](#almacdkopenapixxamazonapigatewayintegrationresponsepropertyresponseparameters) | {[ key: string ]: `string`} | Specifies parameter mappings for the response. |
+| [`responseTemplates`](#almacdkopenapixxamazonapigatewayintegrationresponsepropertyresponsetemplates) | {[ key: string ]: `string`} | Specifies MIME type-specific mapping templates for the response’s payload. |
 
 ---
 
@@ -4438,10 +4408,10 @@ Valid values are 1) CONVERT_TO_TEXT, for converting a binary payload into a base
 ##### `responseParameters`<sup>Optional</sup> <a name="@alma-cdk/openapix.XAmazonApigatewayIntegrationResponse.property.responseParameters" id="almacdkopenapixxamazonapigatewayintegrationresponsepropertyresponseparameters"></a>
 
 ```typescript
-public readonly responseParameters: XAmazonApigatewayIntegrationResponseParameters;
+public readonly responseParameters: {[ key: string ]: string};
 ```
 
-- *Type:* [`@alma-cdk/openapix.XAmazonApigatewayIntegrationResponseParameters`](#@alma-cdk/openapix.XAmazonApigatewayIntegrationResponseParameters)
+- *Type:* {[ key: string ]: `string`}
 
 Specifies parameter mappings for the response.
 
@@ -4452,29 +4422,14 @@ Only the header and body parameters of the integration response can be mapped to
 ##### `responseTemplates`<sup>Optional</sup> <a name="@alma-cdk/openapix.XAmazonApigatewayIntegrationResponse.property.responseTemplates" id="almacdkopenapixxamazonapigatewayintegrationresponsepropertyresponsetemplates"></a>
 
 ```typescript
-public readonly responseTemplates: XAmazonApigatewayIntegrationResponseTemplates;
+public readonly responseTemplates: {[ key: string ]: string};
 ```
 
-- *Type:* [`@alma-cdk/openapix.XAmazonApigatewayIntegrationResponseTemplates`](#@alma-cdk/openapix.XAmazonApigatewayIntegrationResponseTemplates)
+- *Type:* {[ key: string ]: `string`}
 
 Specifies MIME type-specific mapping templates for the response’s payload.
 
 ---
-
-### XAmazonApigatewayIntegrationResponseParameters <a name="@alma-cdk/openapix.XAmazonApigatewayIntegrationResponseParameters" id="almacdkopenapixxamazonapigatewayintegrationresponseparameters"></a>
-
-Specifies mappings from integration method response parameters to method response parameters.
-
-You can map header, body, or static values to the header type of the method response.
-
-#### Initializer <a name="[object Object].Initializer" id="object-objectinitializer"></a>
-
-```typescript
-import { XAmazonApigatewayIntegrationResponseParameters } from '@alma-cdk/openapix'
-
-const xAmazonApigatewayIntegrationResponseParameters: XAmazonApigatewayIntegrationResponseParameters = { ... }
-```
-
 
 ### XAmazonApigatewayIntegrationResponses <a name="@alma-cdk/openapix.XAmazonApigatewayIntegrationResponses" id="almacdkopenapixxamazonapigatewayintegrationresponses"></a>
 
@@ -4488,21 +4443,6 @@ Defines the method's responses and specifies parameter mappings or payload mappi
 import { XAmazonApigatewayIntegrationResponses } from '@alma-cdk/openapix'
 
 const xAmazonApigatewayIntegrationResponses: XAmazonApigatewayIntegrationResponses = { ... }
-```
-
-
-### XAmazonApigatewayIntegrationResponseTemplates <a name="@alma-cdk/openapix.XAmazonApigatewayIntegrationResponseTemplates" id="almacdkopenapixxamazonapigatewayintegrationresponsetemplates"></a>
-
-Specifies a mapping template to transform the integration response body to the method response body for a given MIME type.
-
-> https://docs.aws.amazon.com/apigateway/latest/developerguide/models-mappings.html#models-mappings-mappings
-
-#### Initializer <a name="[object Object].Initializer" id="object-objectinitializer"></a>
-
-```typescript
-import { XAmazonApigatewayIntegrationResponseTemplates } from '@alma-cdk/openapix'
-
-const xAmazonApigatewayIntegrationResponseTemplates: XAmazonApigatewayIntegrationResponseTemplates = { ... }
 ```
 
 

--- a/API.md
+++ b/API.md
@@ -5181,48 +5181,48 @@ public fetchAllIntegrations()
 ##### `fetchIntegration` <a name="@alma-cdk/openapix.Methods.fetchIntegration" id="almacdkopenapixmethodsfetchintegration"></a>
 
 ```typescript
-public fetchIntegration(method: HTTPMethod)
+public fetchIntegration(method: string)
 ```
 
 ###### `method`<sup>Required</sup> <a name="@alma-cdk/openapix.Methods.parameter.method" id="almacdkopenapixmethodsparametermethod"></a>
 
-- *Type:* [`@alma-cdk/openapix.HTTPMethod`](#@alma-cdk/openapix.HTTPMethod)
+- *Type:* `string`
 
 ---
 
 ##### `hasIntegration` <a name="@alma-cdk/openapix.Methods.hasIntegration" id="almacdkopenapixmethodshasintegration"></a>
 
 ```typescript
-public hasIntegration(method: HTTPMethod)
+public hasIntegration(method: string)
 ```
 
 ###### `method`<sup>Required</sup> <a name="@alma-cdk/openapix.Methods.parameter.method" id="almacdkopenapixmethodsparametermethod"></a>
 
-- *Type:* [`@alma-cdk/openapix.HTTPMethod`](#@alma-cdk/openapix.HTTPMethod)
+- *Type:* `string`
 
 ---
 
 ##### `removeIntegration` <a name="@alma-cdk/openapix.Methods.removeIntegration" id="almacdkopenapixmethodsremoveintegration"></a>
 
 ```typescript
-public removeIntegration(method: HTTPMethod)
+public removeIntegration(method: string)
 ```
 
 ###### `method`<sup>Required</sup> <a name="@alma-cdk/openapix.Methods.parameter.method" id="almacdkopenapixmethodsparametermethod"></a>
 
-- *Type:* [`@alma-cdk/openapix.HTTPMethod`](#@alma-cdk/openapix.HTTPMethod)
+- *Type:* `string`
 
 ---
 
 ##### `setIntegration` <a name="@alma-cdk/openapix.Methods.setIntegration" id="almacdkopenapixmethodssetintegration"></a>
 
 ```typescript
-public setIntegration(method: HTTPMethod, integration: Integration)
+public setIntegration(method: string, integration: Integration)
 ```
 
 ###### `method`<sup>Required</sup> <a name="@alma-cdk/openapix.Methods.parameter.method" id="almacdkopenapixmethodsparametermethod"></a>
 
-- *Type:* [`@alma-cdk/openapix.HTTPMethod`](#@alma-cdk/openapix.HTTPMethod)
+- *Type:* `string`
 
 ---
 
@@ -7967,61 +7967,6 @@ Signifies whether the array is wrapped (for example, <books><book/><book/></book
 ---
 
 ## Enums <a name="Enums" id="enums"></a>
-
-### HTTPMethod <a name="HTTPMethod" id="httpmethod"></a>
-
-| **Name** | **Description** |
-| --- | --- |
-| [`GET`](#almacdkopenapixhttpmethodget) | *No description.* |
-| [`PUT`](#almacdkopenapixhttpmethodput) | *No description.* |
-| [`POST`](#almacdkopenapixhttpmethodpost) | *No description.* |
-| [`DELETE`](#almacdkopenapixhttpmethoddelete) | *No description.* |
-| [`OPTIONS`](#almacdkopenapixhttpmethodoptions) | *No description.* |
-| [`HEAD`](#almacdkopenapixhttpmethodhead) | *No description.* |
-| [`PATCH`](#almacdkopenapixhttpmethodpatch) | *No description.* |
-| [`TRACE`](#almacdkopenapixhttpmethodtrace) | *No description.* |
-
----
-
-#### `GET` <a name="@alma-cdk/openapix.HTTPMethod.GET" id="almacdkopenapixhttpmethodget"></a>
-
----
-
-
-#### `PUT` <a name="@alma-cdk/openapix.HTTPMethod.PUT" id="almacdkopenapixhttpmethodput"></a>
-
----
-
-
-#### `POST` <a name="@alma-cdk/openapix.HTTPMethod.POST" id="almacdkopenapixhttpmethodpost"></a>
-
----
-
-
-#### `DELETE` <a name="@alma-cdk/openapix.HTTPMethod.DELETE" id="almacdkopenapixhttpmethoddelete"></a>
-
----
-
-
-#### `OPTIONS` <a name="@alma-cdk/openapix.HTTPMethod.OPTIONS" id="almacdkopenapixhttpmethodoptions"></a>
-
----
-
-
-#### `HEAD` <a name="@alma-cdk/openapix.HTTPMethod.HEAD" id="almacdkopenapixhttpmethodhead"></a>
-
----
-
-
-#### `PATCH` <a name="@alma-cdk/openapix.HTTPMethod.PATCH" id="almacdkopenapixhttpmethodpatch"></a>
-
----
-
-
-#### `TRACE` <a name="@alma-cdk/openapix.HTTPMethod.TRACE" id="almacdkopenapixhttpmethodtrace"></a>
-
----
-
 
 ### InternalIntegrationType <a name="InternalIntegrationType" id="internalintegrationtype"></a>
 

--- a/API.md
+++ b/API.md
@@ -274,7 +274,7 @@ const apiBaseProps: ApiBaseProps = { ... }
 | [`defaultCors`](#almacdkopenapixapibasepropspropertydefaultcors) | [`@alma-cdk/openapix.CorsIntegration`](#@alma-cdk/openapix.CorsIntegration) | Default CORS configuration. Applied to all path integrations. |
 | [`defaultIntegration`](#almacdkopenapixapibasepropspropertydefaultintegration) | [`@alma-cdk/openapix.Integration`](#@alma-cdk/openapix.Integration) | Add a default integration for paths without explicitly defined integrations. |
 | [`injections`](#almacdkopenapixapibasepropspropertyinjections) | {[ key: string ]: `any`} | Inject any OpenApi v3 data to given schema definition object paths. |
-| [`paths`](#almacdkopenapixapibasepropspropertypaths) | [`@alma-cdk/openapix.Paths`](#@alma-cdk/openapix.Paths) | Integrations for OpenApi Path definitions. |
+| [`paths`](#almacdkopenapixapibasepropspropertypaths) | {[ key: string ]: [`@alma-cdk/openapix.Methods`](#@alma-cdk/openapix.Methods)} | Integrations for OpenApi Path definitions. |
 | [`rejections`](#almacdkopenapixapibasepropspropertyrejections) | `string`[] | Reject fields by absolute object path from generated definition. |
 | [`rejectionsDeep`](#almacdkopenapixapibasepropspropertyrejectionsdeep) | `string`[] | Reject all matching fields from generated definition. |
 | [`upload`](#almacdkopenapixapibasepropspropertyupload) | `boolean` | Schema Definition location (inline vs. |
@@ -351,10 +351,10 @@ Inject any OpenApi v3 data to given schema definition object paths.
 ##### `paths`<sup>Optional</sup> <a name="@alma-cdk/openapix.ApiBaseProps.property.paths" id="almacdkopenapixapibasepropspropertypaths"></a>
 
 ```typescript
-public readonly paths: Paths;
+public readonly paths: {[ key: string ]: Methods};
 ```
 
-- *Type:* [`@alma-cdk/openapix.Paths`](#@alma-cdk/openapix.Paths)
+- *Type:* {[ key: string ]: [`@alma-cdk/openapix.Methods`](#@alma-cdk/openapix.Methods)}
 
 Integrations for OpenApi Path definitions.
 
@@ -436,7 +436,7 @@ const apiProps: ApiProps = { ... }
 | [`defaultCors`](#almacdkopenapixapipropspropertydefaultcors) | [`@alma-cdk/openapix.CorsIntegration`](#@alma-cdk/openapix.CorsIntegration) | Default CORS configuration. Applied to all path integrations. |
 | [`defaultIntegration`](#almacdkopenapixapipropspropertydefaultintegration) | [`@alma-cdk/openapix.Integration`](#@alma-cdk/openapix.Integration) | Add a default integration for paths without explicitly defined integrations. |
 | [`injections`](#almacdkopenapixapipropspropertyinjections) | {[ key: string ]: `any`} | Inject any OpenApi v3 data to given schema definition object paths. |
-| [`paths`](#almacdkopenapixapipropspropertypaths) | [`@alma-cdk/openapix.Paths`](#@alma-cdk/openapix.Paths) | Integrations for OpenApi Path definitions. |
+| [`paths`](#almacdkopenapixapipropspropertypaths) | {[ key: string ]: [`@alma-cdk/openapix.Methods`](#@alma-cdk/openapix.Methods)} | Integrations for OpenApi Path definitions. |
 | [`rejections`](#almacdkopenapixapipropspropertyrejections) | `string`[] | Reject fields by absolute object path from generated definition. |
 | [`rejectionsDeep`](#almacdkopenapixapipropspropertyrejectionsdeep) | `string`[] | Reject all matching fields from generated definition. |
 | [`upload`](#almacdkopenapixapipropspropertyupload) | `boolean` | Schema Definition location (inline vs. |
@@ -514,10 +514,10 @@ Inject any OpenApi v3 data to given schema definition object paths.
 ##### `paths`<sup>Optional</sup> <a name="@alma-cdk/openapix.ApiProps.property.paths" id="almacdkopenapixapipropspropertypaths"></a>
 
 ```typescript
-public readonly paths: Paths;
+public readonly paths: {[ key: string ]: Methods};
 ```
 
-- *Type:* [`@alma-cdk/openapix.Paths`](#@alma-cdk/openapix.Paths)
+- *Type:* {[ key: string ]: [`@alma-cdk/openapix.Methods`](#@alma-cdk/openapix.Methods)}
 
 Integrations for OpenApi Path definitions.
 
@@ -3105,19 +3105,6 @@ A definition of a TRACE operation on this path.
 
 ---
 
-### Paths <a name="@alma-cdk/openapix.Paths" id="almacdkopenapixpaths"></a>
-
-Paths with methods containing integrations.
-
-#### Initializer <a name="[object Object].Initializer" id="object-objectinitializer"></a>
-
-```typescript
-import { Paths } from '@alma-cdk/openapix'
-
-const paths: Paths = { ... }
-```
-
-
 ### PathsObject <a name="@alma-cdk/openapix.PathsObject" id="almacdkopenapixpathsobject"></a>
 
 Holds the relative paths to the individual endpoints and their operations.
@@ -5147,6 +5134,107 @@ public readonly fn: IFunction;
 ---
 
 
+### Methods <a name="@alma-cdk/openapix.Methods" id="almacdkopenapixmethods"></a>
+
+Methods with integrations.
+
+Has to be a class because of JSII limitations.  Because of JSII5000 all getters are renamed to non-getXxx named methods.
+
+#### Initializers <a name="@alma-cdk/openapix.Methods.Initializer" id="almacdkopenapixmethodsinitializer"></a>
+
+```typescript
+import { Methods } from '@alma-cdk/openapix'
+
+new Methods(methods: IMethodIntegrations)
+```
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| [`methods`](#almacdkopenapixmethodsparametermethods)<span title="Required">*</span> | [`@alma-cdk/openapix.IMethodIntegrations`](#@alma-cdk/openapix.IMethodIntegrations) | *No description.* |
+
+---
+
+##### `methods`<sup>Required</sup> <a name="@alma-cdk/openapix.Methods.parameter.methods" id="almacdkopenapixmethodsparametermethods"></a>
+
+- *Type:* [`@alma-cdk/openapix.IMethodIntegrations`](#@alma-cdk/openapix.IMethodIntegrations)
+
+---
+
+#### Methods <a name="Methods" id="methods"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| [`fetchAllIntegrations`](#almacdkopenapixmethodsfetchallintegrations) | Get all integrations. |
+| [`fetchIntegration`](#almacdkopenapixmethodsfetchintegration) | Get an integration for a specific HTTP method. |
+| [`hasIntegration`](#almacdkopenapixmethodshasintegration) | Check if there is an integration for a specific HTTP method. |
+| [`removeIntegration`](#almacdkopenapixmethodsremoveintegration) | Remove integration from a specific HTTP method. |
+| [`setIntegration`](#almacdkopenapixmethodssetintegration) | Add or update an integration for a specific HTTP method. |
+
+---
+
+##### `fetchAllIntegrations` <a name="@alma-cdk/openapix.Methods.fetchAllIntegrations" id="almacdkopenapixmethodsfetchallintegrations"></a>
+
+```typescript
+public fetchAllIntegrations()
+```
+
+##### `fetchIntegration` <a name="@alma-cdk/openapix.Methods.fetchIntegration" id="almacdkopenapixmethodsfetchintegration"></a>
+
+```typescript
+public fetchIntegration(method: HTTPMethod)
+```
+
+###### `method`<sup>Required</sup> <a name="@alma-cdk/openapix.Methods.parameter.method" id="almacdkopenapixmethodsparametermethod"></a>
+
+- *Type:* [`@alma-cdk/openapix.HTTPMethod`](#@alma-cdk/openapix.HTTPMethod)
+
+---
+
+##### `hasIntegration` <a name="@alma-cdk/openapix.Methods.hasIntegration" id="almacdkopenapixmethodshasintegration"></a>
+
+```typescript
+public hasIntegration(method: HTTPMethod)
+```
+
+###### `method`<sup>Required</sup> <a name="@alma-cdk/openapix.Methods.parameter.method" id="almacdkopenapixmethodsparametermethod"></a>
+
+- *Type:* [`@alma-cdk/openapix.HTTPMethod`](#@alma-cdk/openapix.HTTPMethod)
+
+---
+
+##### `removeIntegration` <a name="@alma-cdk/openapix.Methods.removeIntegration" id="almacdkopenapixmethodsremoveintegration"></a>
+
+```typescript
+public removeIntegration(method: HTTPMethod)
+```
+
+###### `method`<sup>Required</sup> <a name="@alma-cdk/openapix.Methods.parameter.method" id="almacdkopenapixmethodsparametermethod"></a>
+
+- *Type:* [`@alma-cdk/openapix.HTTPMethod`](#@alma-cdk/openapix.HTTPMethod)
+
+---
+
+##### `setIntegration` <a name="@alma-cdk/openapix.Methods.setIntegration" id="almacdkopenapixmethodssetintegration"></a>
+
+```typescript
+public setIntegration(method: HTTPMethod, integration: Integration)
+```
+
+###### `method`<sup>Required</sup> <a name="@alma-cdk/openapix.Methods.parameter.method" id="almacdkopenapixmethodsparametermethod"></a>
+
+- *Type:* [`@alma-cdk/openapix.HTTPMethod`](#@alma-cdk/openapix.HTTPMethod)
+
+---
+
+###### `integration`<sup>Required</sup> <a name="@alma-cdk/openapix.Methods.parameter.integration" id="almacdkopenapixmethodsparameterintegration"></a>
+
+- *Type:* [`@alma-cdk/openapix.Integration`](#@alma-cdk/openapix.Integration)
+
+---
+
+
+
+
 ### MockIntegration <a name="@alma-cdk/openapix.MockIntegration" id="almacdkopenapixmockintegration"></a>
 
 Defines Mock integration.
@@ -6450,6 +6538,106 @@ public readonly schema: IReferenceObject | ISchemaObject;
 - *Type:* [`@alma-cdk/openapix.IReferenceObject`](#@alma-cdk/openapix.IReferenceObject) | [`@alma-cdk/openapix.ISchemaObject`](#@alma-cdk/openapix.ISchemaObject)
 
 The schema defining the content of the request, response, or parameter.
+
+---
+
+### IMethodIntegrations <a name="@alma-cdk/openapix.IMethodIntegrations" id="almacdkopenapiximethodintegrations"></a>
+
+- *Implemented By:* [`@alma-cdk/openapix.IMethodIntegrations`](#@alma-cdk/openapix.IMethodIntegrations)
+
+
+#### Properties <a name="Properties" id="properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| [`delete`](#almacdkopenapiximethodintegrationspropertydelete) | [`@alma-cdk/openapix.Integration`](#@alma-cdk/openapix.Integration) | *No description.* |
+| [`get`](#almacdkopenapiximethodintegrationspropertyget) | [`@alma-cdk/openapix.Integration`](#@alma-cdk/openapix.Integration) | *No description.* |
+| [`head`](#almacdkopenapiximethodintegrationspropertyhead) | [`@alma-cdk/openapix.Integration`](#@alma-cdk/openapix.Integration) | *No description.* |
+| [`options`](#almacdkopenapiximethodintegrationspropertyoptions) | [`@alma-cdk/openapix.Integration`](#@alma-cdk/openapix.Integration) | *No description.* |
+| [`patch`](#almacdkopenapiximethodintegrationspropertypatch) | [`@alma-cdk/openapix.Integration`](#@alma-cdk/openapix.Integration) | *No description.* |
+| [`post`](#almacdkopenapiximethodintegrationspropertypost) | [`@alma-cdk/openapix.Integration`](#@alma-cdk/openapix.Integration) | *No description.* |
+| [`put`](#almacdkopenapiximethodintegrationspropertyput) | [`@alma-cdk/openapix.Integration`](#@alma-cdk/openapix.Integration) | *No description.* |
+| [`trace`](#almacdkopenapiximethodintegrationspropertytrace) | [`@alma-cdk/openapix.Integration`](#@alma-cdk/openapix.Integration) | *No description.* |
+
+---
+
+##### `delete`<sup>Optional</sup> <a name="@alma-cdk/openapix.IMethodIntegrations.property.delete" id="almacdkopenapiximethodintegrationspropertydelete"></a>
+
+```typescript
+public readonly delete: Integration;
+```
+
+- *Type:* [`@alma-cdk/openapix.Integration`](#@alma-cdk/openapix.Integration)
+
+---
+
+##### `get`<sup>Optional</sup> <a name="@alma-cdk/openapix.IMethodIntegrations.property.get" id="almacdkopenapiximethodintegrationspropertyget"></a>
+
+```typescript
+public readonly get: Integration;
+```
+
+- *Type:* [`@alma-cdk/openapix.Integration`](#@alma-cdk/openapix.Integration)
+
+---
+
+##### `head`<sup>Optional</sup> <a name="@alma-cdk/openapix.IMethodIntegrations.property.head" id="almacdkopenapiximethodintegrationspropertyhead"></a>
+
+```typescript
+public readonly head: Integration;
+```
+
+- *Type:* [`@alma-cdk/openapix.Integration`](#@alma-cdk/openapix.Integration)
+
+---
+
+##### `options`<sup>Optional</sup> <a name="@alma-cdk/openapix.IMethodIntegrations.property.options" id="almacdkopenapiximethodintegrationspropertyoptions"></a>
+
+```typescript
+public readonly options: Integration;
+```
+
+- *Type:* [`@alma-cdk/openapix.Integration`](#@alma-cdk/openapix.Integration)
+
+---
+
+##### `patch`<sup>Optional</sup> <a name="@alma-cdk/openapix.IMethodIntegrations.property.patch" id="almacdkopenapiximethodintegrationspropertypatch"></a>
+
+```typescript
+public readonly patch: Integration;
+```
+
+- *Type:* [`@alma-cdk/openapix.Integration`](#@alma-cdk/openapix.Integration)
+
+---
+
+##### `post`<sup>Optional</sup> <a name="@alma-cdk/openapix.IMethodIntegrations.property.post" id="almacdkopenapiximethodintegrationspropertypost"></a>
+
+```typescript
+public readonly post: Integration;
+```
+
+- *Type:* [`@alma-cdk/openapix.Integration`](#@alma-cdk/openapix.Integration)
+
+---
+
+##### `put`<sup>Optional</sup> <a name="@alma-cdk/openapix.IMethodIntegrations.property.put" id="almacdkopenapiximethodintegrationspropertyput"></a>
+
+```typescript
+public readonly put: Integration;
+```
+
+- *Type:* [`@alma-cdk/openapix.Integration`](#@alma-cdk/openapix.Integration)
+
+---
+
+##### `trace`<sup>Optional</sup> <a name="@alma-cdk/openapix.IMethodIntegrations.property.trace" id="almacdkopenapiximethodintegrationspropertytrace"></a>
+
+```typescript
+public readonly trace: Integration;
+```
+
+- *Type:* [`@alma-cdk/openapix.Integration`](#@alma-cdk/openapix.Integration)
 
 ---
 
@@ -7779,6 +7967,61 @@ Signifies whether the array is wrapped (for example, <books><book/><book/></book
 ---
 
 ## Enums <a name="Enums" id="enums"></a>
+
+### HTTPMethod <a name="HTTPMethod" id="httpmethod"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| [`GET`](#almacdkopenapixhttpmethodget) | *No description.* |
+| [`PUT`](#almacdkopenapixhttpmethodput) | *No description.* |
+| [`POST`](#almacdkopenapixhttpmethodpost) | *No description.* |
+| [`DELETE`](#almacdkopenapixhttpmethoddelete) | *No description.* |
+| [`OPTIONS`](#almacdkopenapixhttpmethodoptions) | *No description.* |
+| [`HEAD`](#almacdkopenapixhttpmethodhead) | *No description.* |
+| [`PATCH`](#almacdkopenapixhttpmethodpatch) | *No description.* |
+| [`TRACE`](#almacdkopenapixhttpmethodtrace) | *No description.* |
+
+---
+
+#### `GET` <a name="@alma-cdk/openapix.HTTPMethod.GET" id="almacdkopenapixhttpmethodget"></a>
+
+---
+
+
+#### `PUT` <a name="@alma-cdk/openapix.HTTPMethod.PUT" id="almacdkopenapixhttpmethodput"></a>
+
+---
+
+
+#### `POST` <a name="@alma-cdk/openapix.HTTPMethod.POST" id="almacdkopenapixhttpmethodpost"></a>
+
+---
+
+
+#### `DELETE` <a name="@alma-cdk/openapix.HTTPMethod.DELETE" id="almacdkopenapixhttpmethoddelete"></a>
+
+---
+
+
+#### `OPTIONS` <a name="@alma-cdk/openapix.HTTPMethod.OPTIONS" id="almacdkopenapixhttpmethodoptions"></a>
+
+---
+
+
+#### `HEAD` <a name="@alma-cdk/openapix.HTTPMethod.HEAD" id="almacdkopenapixhttpmethodhead"></a>
+
+---
+
+
+#### `PATCH` <a name="@alma-cdk/openapix.HTTPMethod.PATCH" id="almacdkopenapixhttpmethodpatch"></a>
+
+---
+
+
+#### `TRACE` <a name="@alma-cdk/openapix.HTTPMethod.TRACE" id="almacdkopenapixhttpmethodtrace"></a>
+
+---
+
 
 ### InternalIntegrationType <a name="InternalIntegrationType" id="internalintegrationtype"></a>
 

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -26,12 +26,12 @@ export class Api extends SpecRestApi {
    * new openapix.Api(this, 'MyApi', {
    *   source: './schema.yaml',
    *   paths: {
-   *     '/foo': {
+   *     '/foo': new openapix.Methods({
    *       get: new openapix.MockIntegration(this),
-   *     },
-   *     '/bar': {
+   *     }),
+   *     '/bar': new openapix.Methods({
    *       post: new openapix.LambdaIntegration(this, fn),
-   *     },
+   *     }),
    *   }
    * })
    *

--- a/src/api/classes/Methods.ts
+++ b/src/api/classes/Methods.ts
@@ -23,6 +23,11 @@ export class Methods {
   private readonly methods: IMethodIntegrations;
 
   public constructor(methods: IMethodIntegrations) {
+    // check if the methods are empty
+    if (Object.keys(methods).length === 0) {
+      throw new Error('At least one method must be defined');
+    }
+
     this.methods = methods;
   }
 

--- a/src/api/classes/Methods.ts
+++ b/src/api/classes/Methods.ts
@@ -1,0 +1,67 @@
+import { Integration } from '../../integration';
+import { HTTPMethodValue } from '../props';
+
+export interface IMethodIntegrations {
+  get?: Integration;
+  post?: Integration;
+  put?: Integration;
+  delete?: Integration;
+  options?: Integration;
+  head?: Integration;
+  patch?: Integration;
+  trace?: Integration;
+};
+
+/**
+ * Methods with integrations.
+ *
+ * Has to be a class because of JSII limitations.
+ *
+ * Because of JSII5000 all getters are renamed to non-getXxx named methods.
+ */
+export class Methods {
+  private readonly methods: IMethodIntegrations;
+
+  public constructor(methods: IMethodIntegrations) {
+    this.methods = methods;
+  }
+
+  /**
+   * Add or update an integration for a specific HTTP method
+   */
+  public setIntegration(method: HTTPMethodValue, integration: Integration): void {
+    this.methods[method] = integration;
+  }
+
+  /**
+   * Get an integration for a specific HTTP method
+   */
+  public fetchIntegration(method: HTTPMethodValue): Integration | undefined {
+    return this.methods[method];
+  }
+
+  /**
+   * Check if there is an integration for a specific HTTP method
+   */
+  public hasIntegration(method: HTTPMethodValue): boolean {
+    return this.methods.hasOwnProperty(method);
+  }
+
+  /**
+   * Remove integration from a specific HTTP method
+   */
+  public removeIntegration(method: HTTPMethodValue): boolean {
+    if (this.hasIntegration(method)) {
+      delete this.methods[method];
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Get all integrations
+   */
+  public fetchAllIntegrations(): IMethodIntegrations {
+    return this.methods;
+  }
+}

--- a/src/api/classes/index.ts
+++ b/src/api/classes/index.ts
@@ -1,0 +1,1 @@
+export { Methods, IMethodIntegrations } from './Methods';

--- a/src/api/definition.ts
+++ b/src/api/definition.ts
@@ -138,7 +138,7 @@ export class ApiDefinition extends apigateway.ApiDefinition {
   /**
    * Configure all `x-amazon-apigateway-integration` values within OpenApi `paths`.
    */
-  private configurePaths(paths?: Paths, defaultCors?: CorsIntegration, defaultIntegration?: Integration): void {
+  private configurePaths(paths: Paths = {}, defaultCors?: CorsIntegration, defaultIntegration?: Integration): void {
 
     const schemaPaths = getSchemaPaths(this.schema);
     // Check that schema has paths object
@@ -148,7 +148,7 @@ export class ApiDefinition extends apigateway.ApiDefinition {
     }
 
     // Loop through paths to ensure all paths are defined in OpenAPI schema
-    Object.keys(paths || {}).forEach(path => {
+    Object.keys(paths).forEach(path => {
       if (!schemaPaths[path]) {
         const message = `Path ${path} not found in OpenAPI Definition. Check paths-props in definition.`;
         addError(this.scope, message);
@@ -157,7 +157,7 @@ export class ApiDefinition extends apigateway.ApiDefinition {
 
     // Loop through all paths defined in the openapi schema to ensure all path integrations are handled
     Object.keys(schemaPaths).map((path: string) => {
-      if (!defaultIntegration && (!paths || !paths[path])) {
+      if (!defaultIntegration &&!paths[path]) {
         const message = `Missing integration for path: ${path}. Check paths-props in definition, or add a default integration.`;
         addError(this.scope, message);
         return;
@@ -166,7 +166,7 @@ export class ApiDefinition extends apigateway.ApiDefinition {
         this.configureDefaultCors(path, defaultCors);
       }
 
-      const methods = paths ? paths[path] : undefined;
+      const methods = paths[path];
       this.configurePathMethods(path, schemaPaths[path], methods, defaultIntegration, defaultCors );
     });
   }

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,2 +1,3 @@
-export { ApiProps, ApiBaseProps, Paths, Methods, Validator } from './props';
+export { ApiProps, ApiBaseProps, Paths, Validator, HTTPMethodValue, HTTPMethod } from './props';
+export * from './classes';
 export { Api } from './api';

--- a/src/api/props.ts
+++ b/src/api/props.ts
@@ -1,4 +1,5 @@
 import { RestApiProps } from 'aws-cdk-lib/aws-apigateway';
+import { Methods } from './classes/Methods';
 import { AuthorizerConfig } from '../authorizers/authorizer';
 import { Integration } from '../integration/base';
 import { CorsIntegration } from '../integration/cors';
@@ -39,9 +40,9 @@ export interface ApiBaseProps {
    *
    * @example
    * {
-   *   '/message': {
+   *   '/message': new Methods({
    *     post: new openapix.LambdaIntegration(this, fn),
-   *   },
+   *   }),
    * }
    */
   readonly paths?: Paths;
@@ -149,38 +150,29 @@ export interface ApiProps extends ApiBaseProps {
   readonly restApiProps?: RestApiProps;
 }
 
-/** Paths with methods containing integrations. */
-export interface Paths {
-  /**
-     * {
-     *   '/message': {
-     *     post: new openapix.LambdaIntegration(this, fn),
-     *   },
-     * }
-     *
-     * @jsii ignore
-     */
-  [path: string]: Methods;
-}
+/** Paths with methods containing integrations.
+ *
+ * @example
+ * {
+ *   '/message': {
+ *     post: new openapix.LambdaIntegration(this, fn),
+ *   },
+ * }
+ */
+export type Paths = Record<string, Methods>;
 
-export enum HTTPMethod {
-  get = 'get',
-  put = 'put',
-  post = 'post',
-  delete = 'delete',
-  options = 'options',
-  head = 'head',
-  patch = 'patch',
-  trace = 'trace'
-}
+export const HTTPMethod = {
+  GET: 'get',
+  PUT: 'put',
+  POST: 'post',
+  DELETE: 'delete',
+  OPTIONS: 'options',
+  HEAD: 'head',
+  PATCH: 'patch',
+  TRACE: 'trace',
+} as const;
 
-/** Methods with integrations. */
-export type Methods = {
-  /**
-   * Integration of an operation on this path.
-   */
-  [key in HTTPMethod]?: Integration;
-}
+export type HTTPMethodValue = typeof HTTPMethod[keyof typeof HTTPMethod];
 
 /** Validator configuration  */
 export interface Validator extends XAmazonApigatewayRequestValidator {

--- a/src/api/props.ts
+++ b/src/api/props.ts
@@ -40,7 +40,7 @@ export interface ApiBaseProps {
    *
    * @example
    * {
-   *   '/message': new Methods({
+   *   '/message': new openapix.Methods({
    *     post: new openapix.LambdaIntegration(this, fn),
    *   }),
    * }

--- a/src/api/utils.ts
+++ b/src/api/utils.ts
@@ -1,4 +1,4 @@
-import { HTTPMethod } from './props';
+import { HTTPMethod, HTTPMethodValue } from './props';
 import { Schema } from '../schema';
 
 const getSchemaPaths = (schema: Schema) => {
@@ -12,13 +12,14 @@ const getSchemaPaths = (schema: Schema) => {
   }, {});
 };
 
-const getMethodsFromSchemaPath = (path: Record<string, any>): {[key in HTTPMethod]?: any} =>
-  Object.keys(path)
-    .reduce((acc: {[key in HTTPMethod]?: any}, pathKey) => {
-      if (pathKey in HTTPMethod) {
-        acc[pathKey as HTTPMethod] = path[pathKey];
-      }
-      return acc;
-    }, {});
+const getMethodsFromSchemaPath = (path: Record<string, any>): {[key in HTTPMethodValue]?: any} => {
+  return Object.entries(HTTPMethod).reduce((acc, [_, methodValue]) => {
+    if (methodValue in path) {
+      // TypeScript knows methodValue is a HTTPMethodValue, so it can be used as a key in acc
+      acc[methodValue] = path[methodValue];
+    }
+    return acc;
+  }, {} as {[key in HTTPMethodValue]?: any});
+};
 
 export { getSchemaPaths, getMethodsFromSchemaPath };

--- a/src/schema/asset/asset.test.ts
+++ b/src/schema/asset/asset.test.ts
@@ -6,6 +6,7 @@ import * as lambda from 'aws-cdk-lib/aws-lambda';
 import { SchemaAsset } from '.';
 import { AwsIntegration, CognitoUserPoolsAuthorizer, LambdaIntegration, Schema } from '../..';
 import { Api } from '../../api';
+import { Methods } from '../../api/classes/Methods';
 
 
 describe('SchemaAsset', () => {
@@ -17,7 +18,7 @@ describe('SchemaAsset', () => {
     const userPool = new cognito.UserPool(stack, 'MyUserPool');
 
     const handler = new lambda.Function(stack, 'MyFunction', {
-      runtime: lambda.Runtime.NODEJS_12_X,
+      runtime: lambda.Runtime.NODEJS_20_X,
       handler: 'index.handler',
       code: lambda.Code.fromInline(`module.exports = {
           handler: async (event) => {
@@ -89,7 +90,7 @@ describe('SchemaAsset', () => {
         }),
       ],
       paths: {
-        '/item': {
+        '/item': new Methods({
           post: new LambdaIntegration(stack, handler),
           get: new AwsIntegration(stack, {
             validator: 'params-only',
@@ -109,7 +110,7 @@ describe('SchemaAsset', () => {
               },
             },
           }),
-        },
+        }),
       },
     });
 

--- a/src/schema/idocument.ts
+++ b/src/schema/idocument.ts
@@ -596,7 +596,6 @@ export interface IReferenceObject extends IExtensible {
    * @jsii ignore
    */
   [key: string]: string;
-  //$ref: string; can't be done because JSII 8002
 }
 
 

--- a/src/schema/props.ts
+++ b/src/schema/props.ts
@@ -596,7 +596,6 @@ export interface ReferenceObject extends Extensible {
    * @jsii ignore
    */
   readonly [key: string]: string;
-  //readonly $ref: string; can't be done because JSII 8002
 }
 
 

--- a/src/x-amazon-apigateway/integration-request-parameters.ts
+++ b/src/x-amazon-apigateway/integration-request-parameters.ts
@@ -4,22 +4,16 @@
  * Specifies mappings from named method request parameters to integration request parameters.
  * The method request parameters must be defined before being referenced.
  *
+ * The value is typically a predefined method request parameter of the
+ * `method.request.<param-type>.<param-name>` format, where `<param-type>`
+ * can be querystring, path, header, or body.
+ *
+ * However, $context.VARIABLE_NAME, $stageVariables.VARIABLE_NAME,
+ * and STATIC_VALUE are also valid.
+ *
+ * For the body parameter, the <param-name> is a JSON path expression
+ * without the $. prefix.
+ *
  * @see https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-swagger-extensions-integration-requestParameters.html
  */
-export interface XAmazonApigatewayIntegrationRequestParameters {
-
-  /**
-   * The value is typically a predefined method request parameter of the
-   * `method.request.<param-type>.<param-name>` format, where `<param-type>`
-   * can be querystring, path, header, or body.
-   *
-   * However, $context.VARIABLE_NAME, $stageVariables.VARIABLE_NAME,
-   * and STATIC_VALUE are also valid.
-   *
-   * For the body parameter, the <param-name> is a JSON path expression
-   * without the $. prefix.
-   *
-   * @jsii ignore
-   */
-  [parameter: string]: string;
-}
+export type XAmazonApigatewayIntegrationRequestParameters = Record<string, string>;

--- a/src/x-amazon-apigateway/integration-request-templates.ts
+++ b/src/x-amazon-apigateway/integration-request-templates.ts
@@ -1,13 +1,7 @@
 /**
  * Specifies mapping templates for a request payload of the specified MIME types.
+ *
+ * @example
+ * 'application/json'
  */
-export interface XAmazonApigatewayIntegrationRequestTemplates {
-
-  /**
-   * @example
-   * 'application/json'
-   *
-   * @jsii ignore
-   */
-  [mimeType: string]: string;
-}
+export type XAmazonApigatewayIntegrationRequestTemplates = Record<string, string>;

--- a/src/x-amazon-apigateway/integration-response-parameters.ts
+++ b/src/x-amazon-apigateway/integration-response-parameters.ts
@@ -4,17 +4,12 @@
  * Specifies mappings from integration method response parameters to method response parameters.
  * You can map header, body, or static values to the header type of the method response.
  *
+ * The named parameter value can be derived from the header and body types of the integration response parameters.
+ *
  * @example
  * {
  *   'method.response.header.Location' : 'integration.response.body.redirect.url',
  *   'method.response.header.x-user-id' : 'integration.response.header.x-userid'
  * }
  */
-export interface XAmazonApigatewayIntegrationResponseParameters {
-  /**
-   * The named parameter value can be derived from the header and body types of the integration response parameters.
-   *
-   * @jsii ignore
-   */
-  [parameter: string]: string;
-}
+export type XAmazonApigatewayIntegrationResponseParameters = Record<string, string>;

--- a/src/x-amazon-apigateway/integration-response-templates.ts
+++ b/src/x-amazon-apigateway/integration-response-templates.ts
@@ -9,15 +9,4 @@
  *   'application/json': '#set ($root=$input.path('$')) { \"stage\": \"$root.name\", \"user-id\": \"$root.key\" }',
  * }
  */
-export interface XAmazonApigatewayIntegrationResponseTemplates {
-
-  /**
-   * @example
-   * {
-   *   'application/json': '#set ($root=$input.path('$')) { \"stage\": \"$root.name\", \"user-id\": \"$root.key\" }',
-   * }
-   *
-   * @jsii ignore
-   */
-  [mimeType: string]: string;
-}
+export type XAmazonApigatewayIntegrationResponseTemplates = Record<string, string>;

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -14,7 +14,7 @@ test('Validators', () => {
   const app = new cdk.App();
   const stack = new cdk.Stack(app, 'TestStack');
   const fn = new lambda.Function(stack, 'TestFunction', {
-    runtime: lambda.Runtime.NODEJS_12_X,
+    runtime: lambda.Runtime.NODEJS_20_X,
     handler: 'index.handler',
     code: lambda.Code.fromInline(`module.exports = {
       handler: async (event) => {
@@ -76,11 +76,11 @@ test('Validators', () => {
       },
     },
     paths: {
-      [path]: {
+      [path]: new openapix.Methods({
         get: new openapix.LambdaIntegration(stack, fn, {
           validator: 'params-only',
         }),
-      },
+      }),
     },
   });
 
@@ -118,7 +118,7 @@ test('Synth', () => {
   const stack = new cdk.Stack(app, 'TestStack');
 
   const fn = new lambda.Function(stack, 'TestFunction', {
-    runtime: lambda.Runtime.NODEJS_12_X,
+    runtime: lambda.Runtime.NODEJS_20_X,
     handler: 'index.handler',
     code: lambda.Code.fromInline(`module.exports = {
       handler: async (event) => {
@@ -203,9 +203,9 @@ test('Synth', () => {
       authType: 'custom',
     })],
     paths: {
-      [path]: {
+      [path]: new openapix.Methods({
         get: new openapix.LambdaIntegration(stack, fn),
-      },
+      }),
     },
   });
 
@@ -503,12 +503,12 @@ test('Handles custom authorizer', () => {
     ],
 
     paths: {
-      '/foo': {
+      '/foo': new openapix.Methods({
         get: new openapix.LambdaIntegration(stack, testLambda),
-      },
-      '/bar': {
+      }),
+      '/bar': new openapix.Methods({
         get: new openapix.LambdaIntegration(stack, testLambda),
-      },
+      }),
     },
   });
 
@@ -647,12 +647,12 @@ test('Handles cross-stack imports inside cdk-app', () => {
     ],
 
     paths: {
-      '/foo': {
+      '/foo': new openapix.Methods({
         get: new openapix.LambdaIntegration(stack, testLambda),
-      },
-      '/bar': {
+      }),
+      '/bar': new openapix.Methods({
         get: new openapix.LambdaIntegration(stack, testLambda),
-      },
+      }),
     },
   });
 

--- a/test/definition.test.ts
+++ b/test/definition.test.ts
@@ -107,9 +107,9 @@ test('Should add errors when wrong path config', () => {
   const definition = new ApiDefinition(stack, {
     source: new openapix.Schema(value),
     paths: {
-      '/notexistingpath': {
+      '/notexistingpath': new openapix.Methods({
         get: new openapix.MockIntegration(),
-      },
+      }),
     },
   });
 
@@ -208,12 +208,12 @@ test('Should add mock integrations', () => {
   const definition = new ApiDefinition(stack, {
     source: new openapix.Schema(value),
     paths: {
-      '/foo': {
+      '/foo': new openapix.Methods({
         get: new openapix.LambdaIntegration(stack, sampleLambdaFunction),
-      },
-      '/bar': {
+      }),
+      '/bar': new openapix.Methods({
         get: new openapix.LambdaIntegration(stack, sampleLambdaFunction),
-      },
+      }),
     },
     defaultIntegration: new MockIntegration(),
   });
@@ -304,17 +304,17 @@ test('Should add cors integrations', () => {
       methods: '*',
     }),
     paths: {
-      '/foo': {
+      '/foo': new openapix.Methods({
         get: new openapix.LambdaIntegration(stack, sampleLambdaFunction),
-      },
-      '/bar': {
+      }),
+      '/bar': new openapix.Methods({
         get: new openapix.LambdaIntegration(stack, sampleLambdaFunction),
         options: new CorsIntegration(stack, {
           headers: OVERRIDE_HEADERS,
           origins: '*',
           methods: '*',
         }),
-      },
+      }),
     },
 
   });


### PR DESCRIPTION
JSII has silently skipped index signatures in 1.x versions as mentioned [here](https://aws.github.io/jsii/user-guides/lib-author/typescript-restrictions/). In the future, methods must be defined as Methods-class to allow jsii compiling to non-ts languages. There are still a lot of jsii ignored parts left (related to openapi spec interfaces)